### PR TITLE
Update App Service Java SDK Doc to use latest Azure Java SDK Track2

### DIFF
--- a/docs-ref-services/latest/appservice.md
+++ b/docs-ref-services/latest/appservice.md
@@ -5,7 +5,7 @@ keywords: Azure, Java, SDK, API, web apps , mobile , App Service
 author: rloutlaw
 ms.author: routlaw
 manager: douge
-ms.date: 07/09/2017
+ms.date: 10/09/2021
 ms.topic: reference
 ms.prod: azure
 ms.technology: azure
@@ -21,6 +21,7 @@ Deploy and manage websites, web applications, and REST APIs with [Azure App Serv
 
 To get started with Azure App Service, see [Create your first Java web app in Azure](/azure/app-service-web/app-service-web-get-started-java).
 
+
 ## Management API
 
 Deploy, scale, and configure applications in Azure App Service with the management API.
@@ -29,14 +30,16 @@ Deploy, scale, and configure applications in Azure App Service with the manageme
 
 ```XML
 <dependency>
-    <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-mgmt-appservice</artifactId>
-    <version>1.3.0</version>
+  <groupId>com.azure.resourcemanager</groupId>
+  <artifactId>azure-resourcemanager-appservice</artifactId>
+  <version>2.8.0</version>
 </dependency>
 ```   
 
 > [!div class="nextstepaction"]
-> [Explore the Management APIs](/java/api/overview/azure/appservice/management)
+> [Explore the Management APIs](/java/api/com.azure.resourcemanager.appservice)
+
+For more information of using Azure App Service Management API, please refer [here](https://docs.microsoft.com/java/api/overview/azure/resourcemanager-appservice-readme). 
 
 ### Example
 
@@ -48,20 +51,10 @@ WebApp app = azure.webApps().define("newLinuxWebApp")
     .withExistingResourceGroup("myResourceGroup")
     .withPrivateDockerHubImage("username/my-java-app")
     .withCredentials("dockerHubUser","dockerHubPassword")
-    .withAppSetting("PORT","8080").
+    .withAppSetting("PORT","8080")
     .create();
 ```
 
 ## Samples
 
-[Deploy a web app from FTP or GitHub][1]  
-[Swap between app versions with deployment slots][2]  
-[Configure a custom domain][3]   
-[Scale a web app across multiple regions][4]   
-
-Explore more [sample Java code for Azure App Service](https://azure.microsoft.com/resources/samples/?platform=java&term=appservice) you can use in your apps.
-
-[1]: ../../docs-ref-conceptual/java-sdk-configure-webapp-sources.md
-[2]: https://azure.microsoft.com/resources/samples/app-service-java-manage-staging-and-production-slots-for-web-apps/
-[3]: https://azure.microsoft.com/resources/samples/app-service-java-manage-web-apps-with-custom-domains/
-[4]: https://azure.microsoft.com/resources/samples/app-service-java-scale-web-apps-on-linux/
+Explore more [sample Java code for Azure App Service](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/docs/SAMPLE.md#application-services) you can use in your apps.


### PR DESCRIPTION
Azure Java Management SDK has been upgraded to Track2 (version 2.x.x), and we highly recommend customers to use Track2 SDK.
This article is still using an old version Track1 (version 1.x.x) SDK. I updated the article so that new customers will use Track2 SDK when trying samples in this article.

The **major change** is to upgrade Azure resource manager package version from com.microsoft.azure v1.3.0 (released on 
Sep, 2017) to com.azure.resourcemanager v2.8.0 (released on Sep, 2021)

Specific changes:
1. Update 'Azure App Service Management API' section  to use Track2 dependency and link toTrack2 API.
2. Update 'Samples' section to use the latest samples, also remove the existing sample links, since they are 404. 